### PR TITLE
Separate pre-linkage and post-linkage triggers

### DIFF
--- a/metadata_merge_trigger.py
+++ b/metadata_merge_trigger.py
@@ -1,0 +1,51 @@
+from airflow import DAG
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.operators.dummy import DummyOperator
+from datetime import timedelta, datetime
+
+from dataloader.airflow_utils.slack import task_fail_slack_alert
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2022, 3, 5),
+    "email": ["jennifer.melot@georgetown.edu"],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert
+}
+
+with DAG("org_er_and_metadata_merge",
+            default_args=default_args,
+            description="Triggers Org ER and metadata merge dags",
+            schedule_interval=None,
+            catchup=False
+         ) as dag:
+
+    trigger_orgfixes1 = TriggerDagRunOperator(
+        task_id="trigger_orgfixes1",
+        trigger_dag_id="org_fixes",
+        wait_for_completion=True
+    )
+    trigger_bulk_org_er_updater = TriggerDagRunOperator(
+        task_id="trigger_bulk_org_er_updater",
+        trigger_dag_id="bulk_org_er_updater",
+        wait_for_completion=True
+    )
+    trigger_orgfixes2 = TriggerDagRunOperator(
+        task_id="trigger_orgfixes2",
+        trigger_dag_id="org_fixes",
+        wait_for_completion=True
+    )
+    trigger_merge = TriggerDagRunOperator(
+        task_id="trigger_merged_article_metadata_updater",
+        trigger_dag_id="merged_article_metadata_updater",
+        wait_for_completion=True
+    )
+
+    trigger_orgfixes1 >> trigger_bulk_org_er_updater >> trigger_orgfixes2 >> trigger_merge
+
+

--- a/push_to_airflow.sh
+++ b/push_to_airflow.sh
@@ -1,5 +1,6 @@
 gsutil cp linkage_dag.py gs://us-east1-production2023-cc1-01d75926-bucket/dags/
 gsutil cp scholarly_lit_trigger.py gs://us-east1-production2023-cc1-01d75926-bucket/dags/
+gsutil cp metadata_merge_trigger.py gs://us-east1-production2023-cc1-01d75926-bucket/dags/
 gsutil rm -r gs://us-east1-production2023-cc1-01d75926-bucket/dags/sql/article_linkage/*
 gsutil -m cp sql/* gs://us-east1-production2023-cc1-01d75926-bucket/dags/sql/article_linkage/
 gsutil rm -r gs://us-east1-production2023-cc1-01d75926-bucket/dags/sequences/article_linkage/*

--- a/scholarly_lit_trigger.py
+++ b/scholarly_lit_trigger.py
@@ -40,17 +40,3 @@ with DAG("scholarly_lit_trigger",
             wait_for_completion=True
         )
         start >> trigger >> trigger_linkage
-
-    trigger_bulk_er = TriggerDagRunOperator(
-        task_id="trigger_bulk_org_er_updater",
-        trigger_dag_id="bulk_org_er_updater",
-        wait_for_completion=True
-    )
-
-    trigger_metadata_merge = TriggerDagRunOperator(
-        task_id="trigger_merged_article_metadata_updater",
-        trigger_dag_id="merged_article_metadata_updater",
-        wait_for_completion=True
-    )
-
-    trigger_linkage >> trigger_bulk_er >> trigger_metadata_merge


### PR DESCRIPTION
This creates two trigger dags, one that runs clarivate tables/s2, then linkage, and another, triggered from linkage, that runs org er and metadata merge. I'll replace this with a better system when I start work on pipeline improvements in another month or two, but in the meantime this avoids the problem of the linkage task potentially timing out because it takes so long to run. Continued in https://github.com/georgetown-cset/cset_article_schema/pull/123