### PR TITLE
Trigger affiliations DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ always reflect outputs on current metadata for a given merged article regardless
 We automate article linkage using Apache Airflow. `linkage_dag.py` contains our current implementation.
 
 * This dag is triggered from the [Semantic Scholar ETL dag](https://github.com/georgetown-cset/semantic-scholar-etl-pipeline/blob/main/s2_dag.py) which runs once a month.
-* This dag triggers the [Org Fixes dag](https://github.com/georgetown-cset/org-fixes/blob/main/org_fixes_dag.py).
+* This dag triggers the [affiliations dag](https://github.com/georgetown-cset/author-affiliations/blob/main/pipeline/affiliations_dag.py).
 
 The DAG generates two tables of analytic significance:
 

--- a/linkage_dag.py
+++ b/linkage_dag.py
@@ -636,9 +636,9 @@ with DAG(
         python_callable=clean_backups,
     )
     success_alert = get_post_success("Article linkage update succeeded!", dag)
-    trigger_org_fixes = TriggerDagRunOperator(
-        task_id="trigger_org_fixes",
-        trigger_dag_id="org_fixes",
+    trigger_affiliations = TriggerDagRunOperator(
+        task_id="trigger_affiliations",
+        trigger_dag_id="affiliations",
     )
 
     curr_date = datetime.now().strftime("%Y%m%d")
@@ -678,7 +678,7 @@ with DAG(
             >> pop_descriptions
             >> update_archive
             >> success_alert
-            >> trigger_org_fixes
+            >> trigger_affiliations
         )
 
     # We don't show the "all metadata" table in the production dataset, but we do need to


### PR DESCRIPTION
The new author affiliations pipeline will run after article linkage. We'll no longer use the org-fixes DAG.